### PR TITLE
remove conn.Serve

### DIFF
--- a/yamux.go
+++ b/yamux.go
@@ -40,18 +40,6 @@ func (c *conn) AcceptStream() (smux.Stream, error) {
 	return s, err
 }
 
-// Serve starts listening for incoming requests and handles them
-// using given StreamHandler
-func (c *conn) Serve(handler smux.StreamHandler) {
-	for { // accept loop
-		s, err := c.AcceptStream()
-		if err != nil {
-			return // err always means closed.
-		}
-		go handler(s)
-	}
-}
-
 // Transport is a go-peerstream transport that constructs
 // yamux-backed connections.
 type Transport yamux.Config


### PR DESCRIPTION
`Serve` will be removed from the `smux.Conn` interface in https://github.com/libp2p/go-stream-muxer/pull/16, which is a prerequisite for the QUIC merge (see https://github.com/libp2p/go-libp2p-transport/pull/20).