### PR TITLE
copy default config to account for new struct members

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/whyrusleeping/go-smux-yamux
+
+go 1.12
+
+require (
+	github.com/libp2p/go-stream-muxer v0.0.1
+	github.com/whyrusleeping/yamux v1.2.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOSqcmlfs=
+github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
+github.com/libp2p/go-stream-muxer v0.0.1 h1:Ce6e2Pyu+b5MC1k3eeFtAax0pW4gc6MosYSLV05UeLw=
+github.com/libp2p/go-stream-muxer v0.0.1/go.mod h1:bAo8x7YkSpadMTbtTaxGVHWUQsR/l5MEaHbKaliuT14=
+github.com/whyrusleeping/yamux v1.2.0 h1:PzUrk7/Z0g/N5V4/+DesmKXYcCToALgj+SbATgs0B34=
+github.com/whyrusleeping/yamux v1.2.0/go.mod h1:Cgw3gpb4DrDZ1FrP/5pxg/cpiY54Gr5uCXwUylwi2GE=


### PR DESCRIPTION
Otherwise it will be zero, which disables coalescing.